### PR TITLE
Fix animation settings for doughnut and pie chart

### DIFF
--- a/src/ChartJS/widgets/DoughnutChart/DoughnutChart.xml
+++ b/src/ChartJS/widgets/DoughnutChart/DoughnutChart.xml
@@ -43,10 +43,15 @@
                 <category>Animation</category>
                 <description>Animation duration (milliseconds) for responsive resizing. (Note: When implementing multiple charts, there can be problems with rendering. You can set this to 0 when having problems)</description>
             </property>
-            <property key="chartAnimation" type="boolean" required="true" defaultValue="true">
-                <caption>Animation</caption>
+            <property key="animateRotate" type="boolean" required="true" defaultValue="true">
+                <caption>Animate Rotate</caption>
                 <category>Animation</category>
-                <description>Switch animation on and off. Try to switch it off when you have rendering problems with multiple charts on a page</description>
+                <description>Whether to animate the rotation of the chart.</description>
+            </property>
+            <property key="animateScale" type="boolean" required="true" defaultValue="false">
+                <caption>Animate Scale</caption>
+                <category>Animation</category>
+                <description>Whether to animate scaling the chart from the centre.</description>
             </property>
             <property key="animationDuration" type="integer" required="true" defaultValue="1000">
                 <caption>Animation duration</caption>
@@ -225,21 +230,6 @@
                 <caption>Segment Stroke Width</caption>
                 <category>Settings</category>
                 <description>The width of the stroke value in pixels.</description>
-            </property>
-            <property key="animationSteps" type="string" required="true" defaultValue="100">
-                <caption>Animation Steps</caption>
-                <category>Settings</category>
-                <description>Amount of animation steps.</description>
-            </property>
-            <property key="animateRotate" type="boolean" required="true" defaultValue="true">
-                <caption>Animate Rotate</caption>
-                <category>Settings</category>
-                <description>Whether to animate the rotation of the chart.</description>
-            </property>
-            <property key="animateScale" type="boolean" required="true" defaultValue="false">
-                <caption>Animate Scale</caption>
-                <category>Settings</category>
-                <description>Whether to animate scaling the chart from the centre.</description>
             </property>
             <property key="showLegend" type="boolean" required="true" defaultValue="true">
                 <caption>Show Legend (ChartJS)</caption>

--- a/src/ChartJS/widgets/DoughnutChart/widget/DoughnutChart.js
+++ b/src/ChartJS/widgets/DoughnutChart/widget/DoughnutChart.js
@@ -112,17 +112,15 @@ define([
                     //Number - The width of each segment stroke
                     segmentStrokeWidth : this.segmentStrokeWidth,
 
-                    //Number - Amount of animation steps
-                    animationSteps : this.animationSteps,
-
-                    //String - Animation easing effect
-                    animationEasing : this.animationEasing,
-
-                    //Boolean - Whether we animate the rotation of the Doughnut
-                    animateRotate : this.animateRotate,
-
-                    //Boolean - Whether we animate scaling the Doughnut from the centre
-                    animateScale : this.animateScale,
+                    animation : {
+                      //Boolean - Whether we animate the rotation of the Doughnut
+                      animateRotate: this.animateRotate,
+                      //Boolean - Whether we animate scaling the Doughnut from the centre
+                      animateScale: this.animateScale,
+                      duration: this.animationDuration,
+                      //String - Animation easing effect
+                      easing: this.animationEasing
+                    },
 
                     legendCallback : this._legendAlternateCallback,
 

--- a/src/ChartJS/widgets/PieChart/PieChart.xml
+++ b/src/ChartJS/widgets/PieChart/PieChart.xml
@@ -46,10 +46,15 @@
             <category>Animation</category>
             <description>Animation duration (milliseconds) for responsive resizing. (Note: When implementing multiple charts, there can be problems with rendering. You can set this to 0 when having problems)</description>
         </property>
-        <property key="chartAnimation" type="boolean" required="true" defaultValue="true">
-            <caption>Animation</caption>
+        <property key="animateRotate" type="boolean" required="true" defaultValue="true">
+            <caption>Animate Rotate</caption>
             <category>Animation</category>
-            <description>Switch animation on and off. Try to switch it off when you have rendering problems with multiple charts on a page</description>
+            <description>Whether to animate the rotation of the chart.</description>
+        </property>
+        <property key="animateScale" type="boolean" required="true" defaultValue="false">
+            <caption>Animate Scale</caption>
+            <category>Animation</category>
+            <description>Whether to animate scaling the chart from the centre.</description>
         </property>
         <property key="animationDuration" type="integer" required="true" defaultValue="1000">
             <caption>Animation duration</caption>
@@ -227,21 +232,6 @@
             <caption>Segment Stroke Width</caption>
             <category>Settings</category>
             <description>The width of the stroke value in pixels.</description>
-        </property>
-        <property key="animationSteps" type="string" required="true" defaultValue="100">
-            <caption>Animation Steps</caption>
-            <category>Settings</category>
-            <description>Amount of animation steps.</description>
-        </property>
-        <property key="animateRotate" type="boolean" required="true" defaultValue="true">
-            <caption>Animate Rotate</caption>
-            <category>Settings</category>
-            <description>Whether to animate the rotation of the chart.</description>
-        </property>
-        <property key="animateScale" type="boolean" required="true" defaultValue="false">
-            <caption>Animate Scale</caption>
-            <category>Settings</category>
-            <description>Whether to animate scaling the chart from the centre.</description>
         </property>
         <property key="showLegend" type="boolean" required="true" defaultValue="true">
             <caption>Show Legend (ChartJS)</caption>

--- a/src/ChartJS/widgets/PieChart/widget/PieChart.js
+++ b/src/ChartJS/widgets/PieChart/widget/PieChart.js
@@ -116,17 +116,15 @@ define([
                         //Number - The width of each segment stroke
                         segmentStrokeWidth : this.segmentStrokeWidth,
 
-                        //Number - Amount of animation steps
-                        animationSteps : this.animationSteps,
-
-                        //String - Animation easing effect
-                        animationEasing : this.animationEasing,
-
-                        //Boolean - Whether we animate the rotation of the Doughnut
-                        animateRotate : this.animateRotate,
-
-                        //Boolean - Whether we animate scaling the Doughnut from the centre
-                        animateScale : this.animateScale,
+                        animation : {
+                          //Boolean - Whether we animate the rotation of the Doughnut
+                          animateRotate: this.animateRotate,
+                          //Boolean - Whether we animate scaling the Doughnut from the centre
+                          animateScale: this.animateScale,
+                          duration: this.animationDuration,
+                          //String - Animation easing effect
+                          easing: this.animationEasing
+                        },
 
                         legendCallback : this._legendAlternateCallback,
 


### PR DESCRIPTION
Properly pass animateRotate and animateScale setting to the chart.
Remove chartAnimation setting (use animateScale/Rotate instead)